### PR TITLE
chore: add next dev server to .env section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ touch .env.development
 Open the .env.development file in a text editor and add the following:
 
 ```sh
-NEXT_DEV_SERVER_PORT=3001
+NEXT_DEV_SERVER_PORT="3001"
 NEXT_PUBLIC_SDK__AUTHENTICATION_URL="https://graphql.service.fleek.xyz/graphql"
 NEXT_PUBLIC_UI_FLEEK_REST_API_URL="https://api.fleek.xyz"
 NEXT_PUBLIC_UI__DYNAMIC_ENVIRONMENT_ID="de23a5f0-aaa5-412e-8212-4fb056a3b30d"


### PR DESCRIPTION
## Why?
- Adds missing `NEXT_DEV_SERVER_PORT` to .env example to avoid the following `pnpm dev` error:

```
> .scripts/local_requirements

🔎 Port 3000 is free
🔎 Port 3001 is free
🔎 Port 3002 is free
🔎 Port 6006 is free
✅ Required dev ports are free!
✅ Found a .env* file!
🤖 Should start the server at localhost:...
error: option '-p, --port <port>' argument missing
 ELIFECYCLE  Command failed with exit code 1.
```

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
