### PR TITLE
feat: add LegacyPlanUpgradeModal

### DIFF
--- a/.changeset/small-dingos-tickle.md
+++ b/.changeset/small-dingos-tickle.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/dashboard": minor
+---
+
+Add free plan phasing out modal

--- a/src/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal.tsx
+++ b/src/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal.tsx
@@ -1,11 +1,13 @@
 import { Box, Button, Dialog, Text } from '@/ui';
 import { Modal } from '../Modal/Modal';
-import { CloseIcon } from '@dynamic-labs/sdk-react-core';
 import { DividerElement } from '@/ui/Divider/Divider.styles';
 import { FleekLogo } from '../FleekLogo/FleekLogo';
 import { Link } from '../ftw/Link/Link';
 import { useEffect, useState } from 'react';
 import { useAuthContext } from '@/providers/AuthProvider';
+import { useFleekCheckout } from '@/hooks/useFleekCheckout';
+import { useToast } from '@/hooks/useToast';
+import { Icon } from '@/ui';
 
 const PERKS = [
   'Unlimited team members',
@@ -21,6 +23,9 @@ export const LegacyPlanUpgradeModal = () => {
   const [isOpen, setIsOpen] = useState(false);
   const auth = useAuthContext();
   const shownKey = `legacy_plan_modal_shown_${auth.accessToken}`;
+  const checkout = useFleekCheckout();
+  const toast = useToast();
+  const [isLoading, setLoading] = useState(false);
 
   useEffect(() => {
     const shown = localStorage.getItem(shownKey);
@@ -36,6 +41,18 @@ export const LegacyPlanUpgradeModal = () => {
     }
   };
 
+  const handleCheckout = async () => {
+    setLoading(true);
+    try {
+      const response = await checkout.mutateAsync();
+      window.location.href = response.url;
+    } catch (error) {
+      toast.error({ error, log: 'Error upgrading plan. Please try again' });
+    }
+    setLoading(false);
+    localStorage.setItem(shownKey, 'true');
+  };
+
   return (
     <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
       <Dialog.Overlay />
@@ -46,7 +63,7 @@ export const LegacyPlanUpgradeModal = () => {
               <Box>Upgrade your plan</Box>
               <Dialog.Close asChild>
                 <Button size="xs" intent="ghost" className="size-6">
-                  <CloseIcon className="size-4 shrink-0" />
+                  <Icon name="close" className="size-4 shrink-0" />
                 </Button>
               </Dialog.Close>
             </Modal.Heading>
@@ -92,12 +109,11 @@ export const LegacyPlanUpgradeModal = () => {
               </Text>
             </Box>
             <Button
-              loading={false}
-              disabled={false}
+              loading={isLoading}
               intent="accent"
               size="md"
-              className="px-8"
-              onClick={() => {}}
+              className="min-w-[150px]"
+              onClick={handleCheckout}
             >
               Upgrade
             </Button>

--- a/src/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal.tsx
+++ b/src/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal.tsx
@@ -1,0 +1,109 @@
+import { Box, Button, Dialog, Text } from '@/ui';
+import { Modal } from '../Modal/Modal';
+import { CloseIcon } from '@dynamic-labs/sdk-react-core';
+import { DividerElement } from '@/ui/Divider/Divider.styles';
+import { FleekLogo } from '../FleekLogo/FleekLogo';
+import { Link } from '../ftw/Link/Link';
+import { useEffect, useState } from 'react';
+import { useAuthContext } from '@/providers/AuthProvider';
+
+const PERKS = [
+  'Unlimited team members',
+  'Unlimited custom domains',
+  'Unlimited sites',
+  'Email support',
+] as const;
+
+// TODO add link to blog post later
+const LEARN_MORE_LINK = undefined;
+
+export const LegacyPlanUpgradeModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const auth = useAuthContext();
+  const shownKey = `legacy_plan_modal_shown_${auth.accessToken}`;
+
+  useEffect(() => {
+    const shown = localStorage.getItem(shownKey);
+    if (!shown) {
+      setIsOpen(true);
+    }
+  }, [shownKey]);
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (!open) {
+      localStorage.setItem(shownKey, 'true');
+    }
+  };
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
+      <Dialog.Overlay />
+      <Dialog.Portal>
+        <Modal.Content>
+          <Box className="gap-4">
+            <Modal.Heading className="flex justify-between items-center">
+              <Box>Upgrade your plan</Box>
+              <Dialog.Close asChild>
+                <Button size="xs" intent="ghost" className="size-6">
+                  <CloseIcon className="size-4 shrink-0" />
+                </Button>
+              </Dialog.Close>
+            </Modal.Heading>
+            <Text variant="secondary">
+              Your legacy Free Plan is being phased out. To continue hosting on
+              Fleek without interruption, please upgrade your plan as soon as
+              possible.
+              {LEARN_MORE_LINK && (
+                <>
+                  {' '}
+                  <Link href="" variant="accent">
+                    Learn more
+                  </Link>
+                </>
+              )}
+            </Text>
+          </Box>
+          <DividerElement />
+          <Box className="gap-3">
+            <Text variant="primary">What you get:</Text>
+            <ul className="flex flex-col gap-3 font-medium">
+              {PERKS.map((li) => (
+                <li key={li} className="flex gap-3 items-center">
+                  <FleekLogo showTypography={false} />
+                  {li}
+                </li>
+              ))}
+            </ul>
+          </Box>
+          <DividerElement />
+          <Box className="flex-row items-center justify-between">
+            <Box>
+              <Box className="flex-row items-center gap-1">
+                <Text variant="primary" size="lg" weight={700}>
+                  $20
+                </Text>
+                <Text className="secondary mt-[2px]" size="xs">
+                  /mo
+                </Text>
+              </Box>
+              <Text className="secondary" size="xs">
+                + resource usage
+              </Text>
+            </Box>
+            <Button
+              loading={false}
+              disabled={false}
+              intent="accent"
+              size="md"
+              className="px-8"
+              onClick={() => {}}
+            >
+              Upgrade
+            </Button>
+          </Box>
+        </Modal.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal.tsx
+++ b/src/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal.tsx
@@ -4,11 +4,11 @@ import { DividerElement } from '@/ui/Divider/Divider.styles';
 import { FleekLogo } from '../FleekLogo/FleekLogo';
 import { Link } from '../ftw/Link/Link';
 import { useEffect, useState } from 'react';
-import { useAuthContext } from '@/providers/AuthProvider';
 import { useFleekCheckout } from '@/hooks/useFleekCheckout';
 import { useToast } from '@/hooks/useToast';
 import { Icon } from '@/ui';
 import { useBillingContext } from '@/providers/BillingProvider';
+import { useSessionContext } from '@/providers/SessionProvider';
 
 const PERKS = [
   'Unlimited team members',
@@ -20,12 +20,12 @@ const PERKS = [
 // TODO add link to blog post later
 const LEARN_MORE_LINK = undefined;
 
-const SHOWN_KEY_PREFIX = 'legacy_plan_modal_shown_';
+const SHOWN_KEY_PREFIX = 'fleek-xyz-legacy_plan_modal_shown_';
 
 export const LegacyPlanUpgradeModal = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const auth = useAuthContext();
-  const shownKey = `${SHOWN_KEY_PREFIX}${auth.accessToken}`;
+  const session = useSessionContext();
+  const shownKey = `${SHOWN_KEY_PREFIX}${session.project.id}`;
   const checkout = useFleekCheckout();
   const toast = useToast();
   const [isLoading, setLoading] = useState(false);
@@ -39,13 +39,6 @@ export const LegacyPlanUpgradeModal = () => {
   }, [shownKey, billingPlan]);
 
   const flagAsShown = () => {
-    // clean any previous flags
-    for (const key in localStorage) {
-      if (key.startsWith(SHOWN_KEY_PREFIX)) {
-        localStorage.removeItem(key);
-      }
-    }
-    // add new flag
     localStorage.setItem(shownKey, 'true');
   };
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,6 +19,7 @@ import { getQueryParamsToObj } from '@/utils/url';
 // TODO: Rename the util as `cookies` (plural)
 import { cookies } from '@/utils/cookie';
 import HomePage from '@/pages/LandingPage';
+import { LegacyPlanUpgradeModal } from '@/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal';
 
 const App = ({ Component, pageProps, requestCookies }: AppProps) => {
   const getLayout = Component.getLayout ?? ((page) => page);
@@ -86,6 +87,7 @@ const App = ({ Component, pageProps, requestCookies }: AppProps) => {
         {getLayout(<Component {...pageProps} />)}
         <ToastsContainer />
         <FeedbackModal />
+        <LegacyPlanUpgradeModal />
       </Providers>
     </>
   );


### PR DESCRIPTION
## Why?

We show a modal that warns the user of the Free Plan phase out.

## How?

- Add modal
- Add local storage key tied to the access token
- Open modal if local storage value is missing
- On modal close, set local storage value

## Tickets?

- [PLAT-2477](https://linear.app/fleekxyz/issue/PLAT-2477/show-users-a-modal-when-they-are-on-a-legacy-free-plan-alerting-them)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?
![localhost_3001_dashboard_projects_cm88yqku20003rbv7c5akr3t8_home_](https://github.com/user-attachments/assets/6c3cb725-4903-4415-ba08-0de0a71d200c)


