### PR TITLE
chore: prevent close on click outside

### DIFF
--- a/.changeset/serious-rockets-smoke.md
+++ b/.changeset/serious-rockets-smoke.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/dashboard": patch
+---
+
+Prevent close of modal on click outside

--- a/src/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal.tsx
+++ b/src/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal.tsx
@@ -65,7 +65,10 @@ export const LegacyPlanUpgradeModal = () => {
     <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
       <Dialog.Overlay />
       <Dialog.Portal>
-        <Modal.Content>
+        <Modal.Content
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onInteractOutside={(e) => e.preventDefault()}
+        >
           <Box className="gap-4">
             <Modal.Heading className="flex justify-between items-center">
               <Box>Upgrade your plan</Box>


### PR DESCRIPTION
## Why?

Prevent closing modal on click outside.

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [PLAT-2477](https://linear.app/fleekxyz/issue/PLAT-2477/show-users-a-modal-when-they-are-on-a-legacy-free-plan-alerting-them)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
