### PR TITLE
feat(account): implement account deletion with safety checks

### DIFF
--- a/.changeset/mean-radios-juggle.md
+++ b/.changeset/mean-radios-juggle.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/dashboard": minor
+---
+
+Implement account deletion with safety checks

--- a/src/components/Form/FormController.ts
+++ b/src/components/Form/FormController.ts
@@ -1,7 +1,6 @@
 import type { AnyZodObject } from 'zod';
 import zod from 'zod';
 
-
 const DEFAULT_OPTIONS: FormController.FormOptions = {
   validateNotDirty: false,
   validationDebounce: 700,

--- a/src/defined.ts
+++ b/src/defined.ts
@@ -70,7 +70,7 @@ export const getDefined = (key: keyof typeof defined): string => {
 };
 
 export const setDefined = (settings: Partial<Defined>) => {
-  Object.keys(settings).forEach(key => {
+  Object.keys(settings).forEach((key) => {
     if (key in defined) {
       defined[key as keyof Defined] = settings[key as keyof Defined];
     }

--- a/src/fragments/Profile/Settings/Sections/DeleteUser/DeleteUser.tsx
+++ b/src/fragments/Profile/Settings/Sections/DeleteUser/DeleteUser.tsx
@@ -1,43 +1,138 @@
+import { Box, Button, Text, Icon } from '@/ui';
 import { LearnMoreMessage, SettingsBox } from '@/components';
+import { DeleteUserModal } from './DeleteUserModal';
+import useDeleteUser from './useDeleteUser';
+import { useMeQuery } from '@/generated/graphqlClient'; // Import useMeQuery
 import { constants } from '@/constants';
-import { LoadingProps } from '@/types/Props';
-import { Button } from '@/ui';
 
-import { DeleteSiteModal, DeleteSiteModalProps } from './DeleteUserModal';
+const getRestrictionMessage = ({
+  hasUnpaidInvoices,
+  isOnlyOwner,
+  error,
+}: {
+  hasUnpaidInvoices: boolean;
+  isOnlyOwner: boolean;
+  error: string | null;
+}): Array<{ id: string; message: string }> => {
+  const restrictions: Array<{ id: string; message: string }> = [];
 
-export type DeleteUserProps = LoadingProps<
-  Pick<DeleteSiteModalProps, 'username'>
->;
+  if (hasUnpaidInvoices) {
+    restrictions.push({
+      id: 'unpaid-invoices',
+      message:
+        'You have unpaid invoices. Please pay all outstanding invoices before deleting your account.',
+    });
+  }
 
-export const DeleteUser: React.FC<DeleteUserProps> = ({
-  username,
-  isLoading,
-}) => {
+  if (isOnlyOwner) {
+    restrictions.push({
+      id: 'only-owner',
+      message:
+        'You are the only owner of one or more projects that have other team members. Please add another owner to these projects or remove the other members first.',
+    });
+  }
+
+  if (error) {
+    restrictions.push({
+      id: 'error',
+      message: error,
+    });
+  }
+
+  return restrictions;
+};
+
+export const DeleteUser = () => {
+  const {
+    canDeleteAccount,
+    hasUnpaidInvoices,
+    isOnlyOwner,
+    isCheckingOwnership,
+    isCheckingInvoices,
+    error,
+    deleteAccount,
+    isDeletingAccount,
+  } = useDeleteUser();
+  const [meQuery] = useMeQuery();
+  const username = meQuery.data?.user?.username || '';
+
+  const restrictions = getRestrictionMessage({
+    hasUnpaidInvoices: Boolean(hasUnpaidInvoices),
+    isOnlyOwner: Boolean(isOnlyOwner),
+    error,
+  });
+
   return (
     <SettingsBox.Container>
       <SettingsBox.Title>Delete Account</SettingsBox.Title>
       <SettingsBox.Text>
         Delete your Fleek account and all projects, files, and data. This action
         is irreversible.
-      </SettingsBox.Text>
-
-      <SettingsBox.ActionRow>
         <LearnMoreMessage
           href={constants.EXTERNAL_LINK.FLEEK_DOCS_DELETE_ACCOUNT}
         >
           deleting an account
         </LearnMoreMessage>
+      </SettingsBox.Text>
 
-        <DeleteSiteModal username={username}>
-          {isLoading ? (
-            <SettingsBox.Skeleton variant="button" />
-          ) : (
-            <Button intent="neutral" disabled>
-              Delete account
-            </Button>
-          )}
-        </DeleteSiteModal>
+      <Text variant="primary" size="sm" weight={700}>
+        Account deletion checklist:
+      </Text>
+      <SettingsBox.ActionRow>
+        <Box className="gap-2">
+          <Box className="flex-row items-center gap-2">
+            {isCheckingInvoices || hasUnpaidInvoices === null ? (
+              <Icon name="spinner" className="text-neutral-11" />
+            ) : (
+              <Icon
+                name={hasUnpaidInvoices ? 'alert-circled' : 'check-circled'}
+                className={
+                  hasUnpaidInvoices ? 'text-danger-11' : 'text-success-11'
+                }
+              />
+            )}
+            <Text>No unpaid invoices</Text>
+          </Box>
+          <Box className="flex-row items-center gap-2">
+            {isCheckingOwnership || isOnlyOwner === null ? (
+              <Icon name="spinner" className="text-neutral-11" />
+            ) : (
+              <Icon
+                name={isOnlyOwner ? 'alert-circled' : 'check-circled'}
+                className={isOnlyOwner ? 'text-danger-11' : 'text-success-11'}
+              />
+            )}
+            <Text>No project ownership that includes any other members</Text>
+          </Box>
+        </Box>
       </SettingsBox.ActionRow>
+
+      {restrictions.length > 0 && (
+        <Box className="mt-4 gap-2">
+          {restrictions.map((restriction) => (
+            <Text
+              key={restriction.id}
+              className={
+                restriction.id === 'error' ? 'text-danger-11' : 'text-red-11'
+              }
+            >
+              {restriction.message}
+            </Text>
+          ))}
+        </Box>
+      )}
+
+      <DeleteUserModal
+        username={username}
+        onDelete={deleteAccount}
+        isDeleting={isDeletingAccount}
+      >
+        <Box className="mt-4">
+          <Button intent="danger" disabled={!canDeleteAccount}>
+            Delete account
+          </Button>
+        </Box>
+      </DeleteUserModal>
     </SettingsBox.Container>
   );
 };

--- a/src/fragments/Profile/Settings/Sections/DeleteUser/DeleteUserModal.tsx
+++ b/src/fragments/Profile/Settings/Sections/DeleteUser/DeleteUserModal.tsx
@@ -1,50 +1,71 @@
 import { AlertBox, Form, Modal } from '@/components';
-import { ChildrenProps } from '@/types/Props';
-import { Button, Dialog, Text } from '@/ui';
+import type { ChildrenProps } from '@/types/Props';
+import { Button, Dialog, Text, Icon } from '@/ui';
+import zod from 'zod';
 
-export type DeleteSiteModalProps = ChildrenProps<{
-  username?: string;
+export type DeleteUserModalProps = ChildrenProps<{
+  username: string;
+  onDelete: () => Promise<void>;
+  isDeleting: boolean;
 }>;
 
-export const DeleteSiteModal: React.FC<DeleteSiteModalProps> = ({
+export const DeleteUserModal: React.FC<DeleteUserModalProps> = ({
   children,
   username,
+  onDelete,
+  isDeleting,
 }) => {
+  const deleteForm = Form.useForm({
+    values: {
+      username: '',
+    },
+    schema: zod.object({
+      username: zod.literal(username, {
+        errorMap: () => ({ message: 'Incorrect username' }),
+      }),
+    }),
+    onSubmit: onDelete,
+  });
+
   return (
     <Dialog.Root>
       <Dialog.Trigger asChild>{children}</Dialog.Trigger>
       <Dialog.Overlay />
 
-      <Modal.Content>
-        <Text as="h1" variant="primary" size="xl" weight={700}>
-          Delete Account
-        </Text>
-        <Text>
-          Your account will be permanently deleted, including your projects,
-          sites and files.
-        </Text>
+      <Form.Provider value={deleteForm}>
+        <Modal.Content>
+          <Text as="h1" variant="primary" size="xl" weight={700}>
+            Delete Account
+          </Text>
+          <Text>
+            Your account will be permanently deleted, including all your project
+            files, custom domain settings, sites, etc.
+          </Text>
 
-        <AlertBox variant="danger" size="sm">
-          Are you sure you want to proceed? This action is irreversible, and
-          cannot be undone.
-        </AlertBox>
+          <AlertBox variant="danger" size="sm">
+            Are you sure you want to proceed? This action is irreversible, and
+            cannot be undone.
+          </AlertBox>
 
-        <Form.InputField
-          name="username"
-          label={
-            <>
-              Enter your username <b>{username}</b> to continue
-            </>
-          }
-          placeholder={username}
-          disableValidMessage
-        />
+          <Form.InputField
+            name="username"
+            label={
+              <>
+                Enter your username <b>{username}</b> to continue
+              </>
+            }
+            placeholder={username}
+            disableValidMessage
+          />
 
-        <Modal.CTARow>
-          <CloseButton />
-          <Form.SubmitButton intent="danger">Delete account</Form.SubmitButton>
-        </Modal.CTARow>
-      </Modal.Content>
+          <Modal.CTARow>
+            <CloseButton />
+            <Form.SubmitButton intent="danger" disabled={isDeleting}>
+              Delete account
+            </Form.SubmitButton>
+          </Modal.CTARow>
+        </Modal.Content>
+      </Form.Provider>
     </Dialog.Root>
   );
 };

--- a/src/fragments/Profile/Settings/Sections/DeleteUser/useCheckProjectOwnership.ts
+++ b/src/fragments/Profile/Settings/Sections/DeleteUser/useCheckProjectOwnership.ts
@@ -1,0 +1,78 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useClient } from 'urql';
+
+import {
+  useProjectsQuery,
+  useMeQuery,
+  ProjectMembersDocument,
+} from '@/generated/graphqlClient';
+
+type UseCheckProjectOwnershipReturn = {
+  isOnlyOwner: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
+export const useCheckProjectOwnership = (): UseCheckProjectOwnershipReturn => {
+  const [isOnlyOwner, setIsOnlyOwner] = useState<boolean | null>(null);
+  const client = useClient();
+  const [meQuery] = useMeQuery();
+  const [projectsQuery] = useProjectsQuery({
+    variables: {},
+  });
+
+  const checkOwnership = async () => {
+    try {
+      if (!projectsQuery.data?.projects.data || !meQuery.data?.user.id) {
+        return null;
+      }
+
+      const userId = meQuery.data.user.id;
+      const projects = projectsQuery.data.projects.data;
+
+      const projectMemberPromises = projects.map((project) =>
+        client
+          .query(ProjectMembersDocument, {
+            where: { id: project.id },
+          })
+          .toPromise(),
+      );
+
+      const projectMembersResults = await Promise.all(projectMemberPromises);
+
+      for (const result of projectMembersResults) {
+        if (!result.data?.project?.memberships) continue;
+
+        const memberships = result.data.project.memberships;
+        const owners = memberships.filter(
+          (member) => member.permissionGroup.name === 'Owner',
+        );
+
+        if (
+          owners.length === 1 &&
+          owners[0].user.id === userId &&
+          memberships.length > 1
+        ) {
+          return true;
+        }
+      }
+
+      return false;
+    } catch (err) {
+      throw new Error('Failed to check project ownership status');
+    }
+  };
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['project-ownership', meQuery.data?.user.id],
+    queryFn: checkOwnership,
+    enabled: !!projectsQuery.data?.projects.data && !!meQuery.data?.user.id,
+  });
+
+  return {
+    isOnlyOwner: !!data,
+    isLoading: isLoading ?? false,
+    error: error ? (error as Error).message : null,
+  };
+};

--- a/src/fragments/Profile/Settings/Sections/DeleteUser/useCheckUnpaidInvoices.ts
+++ b/src/fragments/Profile/Settings/Sections/DeleteUser/useCheckUnpaidInvoices.ts
@@ -1,0 +1,38 @@
+import { useListInvoices } from '@/fragments/Projects/Settings/Sections/Billing/Invoices/useListInvoices';
+
+type UseCheckUnpaidInvoicesReturn = {
+  hasUnpaidInvoices: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
+export const useCheckUnpaidInvoices = (): UseCheckUnpaidInvoicesReturn => {
+  const {
+    data: invoices,
+    isFetching,
+    error: invoicesError,
+  } = useListInvoices({});
+
+  const hasUnpaidInvoices = (() => {
+    if (invoicesError) {
+      return false;
+    }
+    if (!invoices) {
+      return false;
+    }
+    return invoices.some((invoice) => invoice.status.toUpperCase() !== 'PAID');
+  })();
+
+  const error = (() => {
+    if (invoicesError) {
+      return 'Failed to fetch invoice information';
+    }
+    return null;
+  })();
+
+  return {
+    hasUnpaidInvoices,
+    isLoading: isFetching,
+    error,
+  };
+};

--- a/src/fragments/Profile/Settings/Sections/DeleteUser/useDeleteAccount.ts
+++ b/src/fragments/Profile/Settings/Sections/DeleteUser/useDeleteAccount.ts
@@ -1,0 +1,67 @@
+import { useMutation } from '@tanstack/react-query';
+import { useClient, gql } from 'urql';
+
+import { useMeQuery } from '@/generated/graphqlClient';
+import { useLogout } from '@/hooks/useLogout';
+
+type UseDeleteAccountReturn = {
+  deleteAccount: () => Promise<void>;
+  isDeleting: boolean;
+  error: string | null;
+};
+
+export const useDeleteAccount = (): UseDeleteAccountReturn => {
+  const client = useClient();
+  const [meQuery] = useMeQuery();
+  const { logout } = useLogout();
+
+  // TODO: Make gql follow graphql client convention
+  // which at time of writing relies on a generator from monorepo
+  // that dumps into `src/generated`. The process has to be replaced.
+  const DELETE_USER_MUTATION = gql`
+    mutation DeleteUser($where: DeleteUserWhereInput!) {
+      deleteUser(where: $where) {
+        id
+      }
+    }
+  `;
+
+  const deleteUserMutation = useMutation({
+    mutationKey: ['delete-user'],
+    mutationFn: async () => {
+      const userId = meQuery.data?.user.id;
+      if (!userId) {
+        throw new Error('Could not identify user to delete.');
+      }
+
+      const result = await client
+        .mutation(DELETE_USER_MUTATION, { where: { id: userId } })
+        .toPromise();
+
+      if (result.data?.deleteUser) {
+        return result.data.deleteUser;
+      }
+
+      if (result.error) {
+        throw new Error(
+          result.error.graphQLErrors[0]?.message ||
+            result.error.message ||
+            'Failed to delete account. Please try again.',
+        );
+      }
+
+      throw new Error('Failed to delete account. Unexpected response.');
+    },
+    onSuccess: () => {
+      logout();
+    },
+  });
+
+  return {
+    deleteAccount: () => deleteUserMutation.mutateAsync(),
+    isDeleting: deleteUserMutation.isLoading,
+    error: deleteUserMutation.error
+      ? (deleteUserMutation.error as Error).message
+      : null,
+  };
+};

--- a/src/fragments/Profile/Settings/Sections/DeleteUser/useDeleteUser.ts
+++ b/src/fragments/Profile/Settings/Sections/DeleteUser/useDeleteUser.ts
@@ -1,0 +1,58 @@
+import { useCheckProjectOwnership } from './useCheckProjectOwnership';
+import { useCheckUnpaidInvoices } from './useCheckUnpaidInvoices';
+import { useDeleteAccount } from './useDeleteAccount';
+
+type UseDeleteUserReturn = {
+  canDeleteAccount: boolean;
+  hasUnpaidInvoices: boolean | null;
+  isOnlyOwner: boolean | null;
+  isCheckingOwnership: boolean;
+  isCheckingInvoices: boolean;
+  error: string | null;
+  deleteAccount: () => Promise<void>;
+  isDeletingAccount: boolean;
+};
+
+const useDeleteUser = (): UseDeleteUserReturn => {
+  const {
+    isOnlyOwner,
+    isLoading: isCheckingOwnership,
+    error: ownershipError,
+  } = useCheckProjectOwnership();
+
+  const {
+    hasUnpaidInvoices,
+    isLoading: isCheckingInvoices,
+    error: invoicesError,
+  } = useCheckUnpaidInvoices();
+
+  const {
+    deleteAccount,
+    isDeleting: isDeletingAccount,
+    error: deleteError,
+  } = useDeleteAccount();
+
+  const error = deleteError || ownershipError || invoicesError || null;
+
+  const canDeleteAccount =
+    !error &&
+    !isCheckingOwnership &&
+    !isCheckingInvoices &&
+    hasUnpaidInvoices !== null &&
+    isOnlyOwner !== null &&
+    !hasUnpaidInvoices &&
+    !isOnlyOwner;
+
+  return {
+    canDeleteAccount,
+    hasUnpaidInvoices,
+    isOnlyOwner,
+    isCheckingOwnership,
+    isCheckingInvoices,
+    error,
+    deleteAccount,
+    isDeletingAccount,
+  };
+};
+
+export default useDeleteUser;

--- a/src/fragments/Projects/Agents/AgentsList.tsx
+++ b/src/fragments/Projects/Agents/AgentsList.tsx
@@ -11,7 +11,6 @@ import { useListAgents } from './useListAgents';
 import { joinBase } from '@/utils/paths';
 import { getAgentsUrl } from '@/utils/url';
 
-
 const agentsUrl = getAgentsUrl();
 
 export const AgentsList = () => {

--- a/src/fragments/Projects/Home/AddNewDropdown.tsx
+++ b/src/fragments/Projects/Home/AddNewDropdown.tsx
@@ -11,7 +11,7 @@ import { Button, Menu } from '@/ui';
 import { FLEEK_TEMPLATES_URLS } from '../../../utils/template';
 import { getAgentsUrl } from '@/utils/url';
 
-const agentsUrl =getAgentsUrl();
+const agentsUrl = getAgentsUrl();
 
 export const AddNewDropdown: React.FC = () => {
   const session = useSessionContext();

--- a/src/fragments/Template/TemplateCard/TemplateCard.tsx
+++ b/src/fragments/Template/TemplateCard/TemplateCard.tsx
@@ -24,11 +24,7 @@ export const TemplateCard = forwardStyledRef<
   const templateUrl = joinUrl(templatesUrl, template.siteSlug);
 
   const templateBanner = joinUrl(websiteUrl, template.banner, true);
-  const frameworkAvatar = joinUrl(
-    websiteUrl,
-    template.framework?.avatar,
-    true,
-  );
+  const frameworkAvatar = joinUrl(websiteUrl, template.framework?.avatar, true);
 
   return (
     <LinkBox

--- a/src/graphql/team/queries/projectMembers.gql
+++ b/src/graphql/team/queries/projectMembers.gql
@@ -1,5 +1,6 @@
 query projectMembers($where: ProjectWhereInput!) {
   project(where: $where) {
+    id
     memberships {
       id
       role

--- a/src/hooks/useBlogArticles.ts
+++ b/src/hooks/useBlogArticles.ts
@@ -30,7 +30,10 @@ const fetchBlogArticles = async (
     const parsedArticles: ArticleItemProps[] = slicedData.map((article) => ({
       title: article.title,
       description: article.description,
-      href: joinUrl(getDefined('NEXT_PUBLIC_WEBSITE_URL'), `/blog/${article.slug}`),
+      href: joinUrl(
+        getDefined('NEXT_PUBLIC_WEBSITE_URL'),
+        `/blog/${article.slug}`,
+      ),
       imgSrc: joinUrl(getDefined('NEXT_PUBLIC_WEBSITE_URL'), article.imageSrc),
     }));
 

--- a/src/hooks/useFleekSdk.ts
+++ b/src/hooks/useFleekSdk.ts
@@ -36,10 +36,13 @@ export const useFleekSdk = () => {
 
         const client = new FleekSdk({
           accessTokenService,
-          graphqlServiceApiUrl: getDefined('NEXT_PUBLIC_SDK__AUTHENTICATION_URL'),
+          graphqlServiceApiUrl: getDefined(
+            'NEXT_PUBLIC_SDK__AUTHENTICATION_URL',
+          ),
           uploadProxyApiUrl: getDefined('NEXT_PUBLIC_UI__UPLOAD_PROXY_API_URL'),
-          ipfsStorageApiUrl:
-            getDefined('NEXT_PUBLIC_UI__INTERNAL_IPFS_STORAGE_HOSTNAME'),
+          ipfsStorageApiUrl: getDefined(
+            'NEXT_PUBLIC_UI__INTERNAL_IPFS_STORAGE_HOSTNAME',
+          ),
         });
 
         setFleekSdk(client);

--- a/src/integrations/new-be/BackendApi.ts
+++ b/src/integrations/new-be/BackendApi.ts
@@ -1,7 +1,9 @@
 import { getDefined } from '@/defined';
 
 export class BackendApiClient {
-  private baseURL: string | undefined = getDefined('NEXT_PUBLIC_UI_FLEEK_REST_API_URL');
+  private baseURL: string | undefined = getDefined(
+    'NEXT_PUBLIC_UI_FLEEK_REST_API_URL',
+  );
   private headers: HeadersInit;
 
   constructor(args: BackendApiClient.Arguments) {

--- a/src/integrations/stripe/StripeCheckout.ts
+++ b/src/integrations/stripe/StripeCheckout.ts
@@ -33,7 +33,9 @@ export class StripeCheckout {
   initialize: StripeCheckout.Initialize = async ({ theme, domSelector }) => {
     this.setState('initial');
 
-    this.stripe = await loadStripe(getDefined('NEXT_PUBLIC_UI__STRIPE_PUBLIC_KEY'));
+    this.stripe = await loadStripe(
+      getDefined('NEXT_PUBLIC_UI__STRIPE_PUBLIC_KEY'),
+    );
 
     if (!this.stripe) {
       throw new StripeCheckoutError('Failed to load Stripe');

--- a/src/integrations/urql.tsx
+++ b/src/integrations/urql.tsx
@@ -147,6 +147,7 @@ export const createUrqlClient = ({
     keys: {
       SitesWithAggregation: () => null,
       ProjectsWithAggregation: () => null,
+      Project: (data) => `${data.id}`,
       Site: (data) => `${data.id}`,
       DeploymentsWithAggregation: () => null,
       TemplatesWithAggregation: () => null,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -112,11 +112,14 @@ const App = ({ Component, pageProps, requestCookies }: AppProps) => {
   );
 };
 
-export default dynamic<AppProps>(async () => {
-  await loadConfig();
-  
-  return App;
-}, {
-  ssr: false,
-  loading: () => <LoadingFullScreen />
-});
+export default dynamic<AppProps>(
+  async () => {
+    await loadConfig();
+
+    return App;
+  },
+  {
+    ssr: false,
+    loading: () => <LoadingFullScreen />,
+  },
+);

--- a/src/pages/profile/settings/index.tsx
+++ b/src/pages/profile/settings/index.tsx
@@ -2,14 +2,13 @@ import { useDynamicContext } from '@dynamic-labs/sdk-react-core';
 import { updateUserSchema } from '@fleek-platform/utils-validation';
 import { useClient } from 'urql';
 import { useEnsAvatar, useEnsName } from 'wagmi';
-import zod from 'zod';
 
 import { Form } from '@/components';
 import { Profile } from '@/fragments';
 import { useMeQuery } from '@/generated/graphqlClient';
 import { useUpdateUser } from '@/hooks/useUpdateUser';
-import { Page } from '@/types/App';
-import { HandleLogoUploadProps } from '@/types/Logo';
+import type { Page } from '@/types/App';
+import type { HandleLogoUploadProps } from '@/types/Logo';
 
 const GeneralSettingsPage: Page = () => {
   const [meQuery] = useMeQuery();
@@ -55,25 +54,6 @@ const GeneralSettingsPage: Page = () => {
     });
   };
 
-  const deleteForm = Form.useForm({
-    values: {
-      username: '',
-    },
-    schema: zod.object({
-      username: zod.literal(user?.username, {
-        errorMap: () => ({ message: 'Incorrect username' }),
-      }),
-    }),
-    // TODO: add validation
-    onSubmit: async () => {
-      return new Promise<void>((resolve) => {
-        setTimeout(() => {
-          resolve();
-        }, 3000);
-      });
-    },
-  });
-
   return (
     <>
       <Form.Provider value={renameForm}>
@@ -86,12 +66,7 @@ const GeneralSettingsPage: Page = () => {
         isLoading={meQuery.fetching}
       />
 
-      <Form.Provider value={deleteForm}>
-        <Profile.Settings.Sections.DeleteUser
-          username={user?.username || ''}
-          isLoading={meQuery.fetching}
-        />
-      </Form.Provider>
+      <Profile.Settings.Sections.DeleteUser />
     </>
   );
 };

--- a/src/providers/BillingProvider.tsx
+++ b/src/providers/BillingProvider.tsx
@@ -59,7 +59,9 @@ export const BillingProvider: React.FC<ChildrenProps> = ({ children }) => {
 
     if (
       DateTime.now() <
-      DateTime.fromISO(getDefined('NEXT_PUBLIC_BILLING_FREE_PLAN_DEPRECATION_DATE'))
+      DateTime.fromISO(
+        getDefined('NEXT_PUBLIC_BILLING_FREE_PLAN_DEPRECATION_DATE'),
+      )
     ) {
       return 'free';
     }

--- a/src/providers/PHProvider.tsx
+++ b/src/providers/PHProvider.tsx
@@ -14,7 +14,7 @@ import { CustomPostHogProvider } from './CustomPostHogProvider';
 if (!isServerSide()) {
   posthogJs.init(getDefined('NEXT_PUBLIC_UI__POSTHOG_KEY')!, {
     api_host:
-      getDefined('NEXT_PUBLIC_UI__POSTHOG_HOST')|| 'https://us.i.posthog.com',
+      getDefined('NEXT_PUBLIC_UI__POSTHOG_HOST') || 'https://us.i.posthog.com',
     person_profiles: 'identified_only',
     capture_performance: true,
     capture_pageview: true,

--- a/src/utils/getMaintenanceMode.ts
+++ b/src/utils/getMaintenanceMode.ts
@@ -23,7 +23,7 @@ const updateMaintenanceMode = async (): Promise<void> => {
 const checkMaintenanceMode = async (): Promise<boolean> => {
   try {
     const response = await fetch(
-      getDefined('NEXT_PUBLIC_SDK__AUTHENTICATION_URL')+ '/ping',
+      getDefined('NEXT_PUBLIC_SDK__AUTHENTICATION_URL') + '/ping',
     );
 
     return response.status !== 200;

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -9,10 +9,10 @@ const { templatesAPI, templatesUrl } = constants.FLEEK_TEMPLATES_RELATIVE_PATHS;
 // we must use the `fleek.xyz`
 // this is due to site URL being overriden
 // for the repo's environment fleek-dashboard-
-const websiteUrl = 
+const websiteUrl =
   !isServerSide() && !window.location.hostname.startsWith('fleek-dashboard-')
-  ? getWebsiteUrl()
-  : 'https://fleek.xyz'
+    ? getWebsiteUrl()
+    : 'https://fleek.xyz';
 
 export const FLEEK_TEMPLATES_URLS = {
   websiteUrl,

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -80,5 +80,7 @@ export const getQueryParamsToObj = (search: string) => {
 };
 
 export const getWebsiteUrl = () => getDefined('NEXT_PUBLIC_WEBSITE_URL');
-export const getDashboardUrl = () => joinUrl(getWebsiteUrl(), getDefined('NEXT_PUBLIC_DASHBOARD_BASE_PATH'));
-export const getAgentsUrl = () => joinUrl(getWebsiteUrl(), getDefined('NEXT_PUBLIC_AGENTS_AI_PATH'));
+export const getDashboardUrl = () =>
+  joinUrl(getWebsiteUrl(), getDefined('NEXT_PUBLIC_DASHBOARD_BASE_PATH'));
+export const getAgentsUrl = () =>
+  joinUrl(getWebsiteUrl(), getDefined('NEXT_PUBLIC_AGENTS_AI_PATH'));


### PR DESCRIPTION
## Why?

Implements a secure account deletion flow with pre-deletion validations.
The feature ensures users cannot accidentally delete their account when:
- They have unpaid invoices
- They are the only owner of projects with other team members

## How?

- check for unpaid invoices before deletion
- verify user is not sole owner of projects with members
- add pre-deletion checklist with loading states
- display restriction messages in red with clear instructions
- create useDeleteUser hook for centralized deletion logic

## Tickets?

- [PLAT-149](https://linear.app/fleekxyz/issue/PLAT-149/[delete-account]-fe)
- [PLAT-594](https://linear.app/fleekxyz/issue/PLAT-594/[delete-account]-block-deletion-if-unpaid-invoice)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/40120380-c0f6-4e15-8a28-5847b1952ed0" />
