### PR TITLE
fix: don't show modal until billing plan type is loaded

### DIFF
--- a/.changeset/tasty-dolls-begin.md
+++ b/.changeset/tasty-dolls-begin.md
@@ -1,0 +1,5 @@
+---
+"@fleek-platform/dashboard": patch
+---
+
+fix free plan upgrade modal race condition

--- a/src/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal.tsx
+++ b/src/components/LegacyPlanUpgradeModal/LegacyPlanUpgradeModal.tsx
@@ -29,10 +29,10 @@ export const LegacyPlanUpgradeModal = () => {
   const checkout = useFleekCheckout();
   const toast = useToast();
   const [isLoading, setLoading] = useState(false);
-  const { billingPlanType } = useBillingContext();
+  const { billingPlanType, loading: billingPlanTypeLoading } = useBillingContext();
 
   useEffect(() => {
-    if (billingPlanType !== 'none' && billingPlanType !== 'free') return;
+    if (billingPlanTypeLoading || billingPlanType !== 'none' && billingPlanType !== 'free') return;
     const shown = localStorage.getItem(shownKey);
     if (shown) return;
     setIsOpen(true);


### PR DESCRIPTION
## Why?

Clear and short explanation here.

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You've reviewed spelling using a grammar checker
- [ ] For documentation, guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The Components are escaping output (to prevent XSS)

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
